### PR TITLE
Replace getLine() with getSelection()

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -801,9 +801,7 @@ function _replaceSelection(cm, active, startEnd, url) {
 		end = end.replace("#url#", url);
 	}
 	if(active) {
-		text = cm.getLine(startPoint.line);
-		start = text.slice(0, startPoint.ch);
-		end = text.slice(startPoint.ch);
+		text = cm.getSelection();
 		cm.replaceRange(start + end, {
 			line: startPoint.line,
 			ch: 0


### PR DESCRIPTION
This fixes a bug where multiple markdown link containers would be placed when the "Create Link" button was pushed.